### PR TITLE
Filtering Patch 1

### DIFF
--- a/scripts/sd_tag_batch.py
+++ b/scripts/sd_tag_batch.py
@@ -89,7 +89,8 @@ class Script(scripts.Script):
             interrogator = self.filter_words(interrogator, raw_prompt)
         # Remove negative prompt content from interrogator prompt
         if use_negatives:
-            interrogator = self.filter_words(interrogator, p.negative_prompt)
+            raw_negative = p.negative_prompt
+            interrogator = self.filter_words(interrogator, raw_negative)
 
         if use_weight:
             if p.prompt == "":

--- a/scripts/sd_tag_batch.py
+++ b/scripts/sd_tag_batch.py
@@ -1,4 +1,5 @@
 import gradio as gr
+import re #For remove_attention regular expressions
 from modules import scripts, deepbooru
 from modules.processing import process_images
 import modules.shared as shared
@@ -27,11 +28,53 @@ class Script(scripts.Script):
         )
         use_weight = gr.Checkbox(label="Use Weighted Prompt", value=True)
         use_deepbooru = gr.Checkbox(label="Use deepbooru", value=True)
-        return [in_front, prompt_weight, use_deepbooru, use_weight]
+        no_duplicates = gr.Checkbox(label="Filter Duplicate Prompt Content from Interrogation", value=False)
+        use_negatives = gr.Checkbox(label="Filter Negative Prompt Content from Interrogation", value=False)
+        return [in_front, prompt_weight, use_deepbooru, use_weight, no_duplicates, use_negatives]
 
-    def run(self, p, in_front, prompt_weight, use_deepbooru, use_weight):
+    # Required to parse information from a string that is between () or has :##.## suffix
+    def remove_attention(self, words):
+        # Define a regular expression pattern to match attention-related suffixes
+        pattern = r":\d+(\.\d+)?"
+        # Remove attention-related suffixes using regex substitution
+        words = re.sub(pattern, "", words)
+        
+        # Replace escaped left parenthesis with temporary placeholder
+        words = re.sub(r"\\\(", r"TEMP_LEFT_PLACEHOLDER", words)
+        # Replace escaped right parenthesis with temporary placeholder
+        words = re.sub(r"\\\)", r"TEMP_RIGHT_PLACEHOLDER", words)
+        # Define a regular expression pattern to match parentheses and their content
+        pattern = r"(\(|\))"
+        # Remove parentheses using regex substitution
+        words = re.sub(pattern, "", words)
+        # Restore escaped left parenthesis
+        words = re.sub(r"TEMP_LEFT_PLACEHOLDER", r"\\(", words)
+        # Restore escaped right parenthesis
+        words = re.sub(r"TEMP_RIGHT_PLACEHOLDER", r"\\)", words)
+        
+        return words.strip()
+
+    def filter_words(self, prompt, negative):
+        # Corrects a potential error where negative is nonetype
+        if negative is None:
+            negative = ""
+        
+        # Split prompt and negative strings into lists of words
+        prompt_words = [word.strip() for word in prompt.split(",")]
+        negative_words = [self.remove_attention(word.strip()) for word in negative.split(",")]
+        
+        # Filter out words from prompt that are in negative
+        filtered_words = [word for word in prompt_words if self.remove_attention(word) not in negative_words]
+        
+        # Join filtered words back into a string
+        filtered_prompt = ", ".join(filtered_words)
+        
+        return filtered_prompt
+
+    def run(self, p, in_front, prompt_weight, use_deepbooru, use_weight, no_duplicates, use_negatives):
 
         raw_prompt = p.prompt
+        interrogator = ""
 
         # fix alpha channel
         p.init_images[0] = p.init_images[0].convert("RGB")
@@ -40,17 +83,24 @@ class Script(scripts.Script):
             interrogator = deepbooru.model.tag(p.init_images[0])
         else:
             interrogator = shared.interrogator.interrogate(p.init_images[0])
+        
+        # Remove duplicate prompt content from interrogator prompt
+        if no_duplicates:
+            interrogator = self.filter_words(interrogator, raw_prompt)
+        # Remove negative prompt content from interrogator prompt
+        if use_negatives:
+            interrogator = self.filter_words(interrogator, p.negative_prompt)
 
         if use_weight:
             if p.prompt == "":
-                p.prompt = Script.interrogator
+                p.prompt = interrogator
             elif in_front:
                 p.prompt = f"{p.prompt}, ({interrogator}:{prompt_weight})"
             else:
                 p.prompt = f"({interrogator}:{prompt_weight}), {p.prompt}"
         else:
             if p.prompt == "":
-                p.prompt = Script.interrogator
+                p.prompt = interrogator
             elif in_front:
                 p.prompt = f"{p.prompt}, {interrogator}"
             else:

--- a/scripts/sd_tag_batch.py
+++ b/scripts/sd_tag_batch.py
@@ -28,8 +28,9 @@ class Script(scripts.Script):
         )
         use_weight = gr.Checkbox(label="Use Weighted Prompt", value=True)
         use_deepbooru = gr.Checkbox(label="Use deepbooru", value=True)
-        no_duplicates = gr.Checkbox(label="Filter Duplicate Prompt Content from Interrogation", value=False)
-        use_negatives = gr.Checkbox(label="Filter Negative Prompt Content from Interrogation", value=False)
+        with gr.Accordion("Deepbooru tools:"):
+            no_duplicates = gr.Checkbox(label="Filter Duplicate Prompt Content from Interrogation", value=False)
+            use_negatives = gr.Checkbox(label="Filter Negative Prompt Content from Interrogation", value=False)
         return [in_front, prompt_weight, use_deepbooru, use_weight, no_duplicates, use_negatives]
 
     # Required to parse information from a string that is between () or has :##.## suffix


### PR DESCRIPTION
Two new toggles to filter prompt content from interrogator prompt output.
1. Negative prompt content filtered from the interrogator prompt output (Removes contradictions from the prompt)
2. Prompt content filtered from the interrogator prompt output (Removes duplicates from the prompt)

Both toggles are toggled disabled by default to maintain normal vanilla operation.

**Additional housekeeping change, Script.interrogator changed to interrogator, as Script.interrogator no longer exists.**

So I thought it would be nice if the interrogator did not produce content that contradicted the negative prompt. Such as in the case when you put an image with `flowers` but you have `flowers` in the negative prompt. This will ensure that the interrogator prompt does not add contradictory keywords to the prompt. This should not remove keywords from the negative prompt. Note, that this should only remove exact keywords from the interrogation prompt.

I reused the code for negative prompt removal for duplicate prompt content removal. Such as in the case where the interrogator prompt says `flowers` but the raw prompt already has `flowers`. I think this might assist with memory footprint while SD is running. 

There are a lot of regex substitutions to remove the attention annotation that might be in the prompt or negative prompt. I think that there might be a more efficient way to perform these regex substitutions, but I was unable to achieve a more efficient method. However, I also think that any inefficiency here would still improve SD efficiency, and since it is disabled by default, any potential inefficiency could be opted out of. Technically optimizing the regex to one or two lines would still get O(n), so it would probably be the same big-O time, so optimization of the regex might not do anything. I will include test cases for regex substitution if anyone wants to attempt to improve the regex substitution.

Test cases:
`"man, (beard, happy), fishing:404, (moon, stars:4.04)"
"((boy, girl)), (lily \(flower\)), rose \(flower\)"`

Expected output:
`"man, beard, happy, fishing, moon, stars"
"boy, girl, lily \(flower\), rose \(flower\)"`