### PR TITLE
Filtering Update 2 sd_tag_batch.py

### DIFF
--- a/scripts/sd_tag_batch.py
+++ b/scripts/sd_tag_batch.py
@@ -97,7 +97,7 @@ class Script(scripts.Script):
         
         return filtered_prompt
 
-    def run(self, p, in_front, prompt_weight, model_selection, use_weight, no_duplicates, use_negatives):
+    def run(self, p, in_front, prompt_weight, model_selection, use_weight, no_duplicates, use_negatives, use_custom_filter, custom_filter):
 
         raw_prompt = p.prompt
         interrogator = ""

--- a/scripts/sd_tag_batch.py
+++ b/scripts/sd_tag_batch.py
@@ -3,12 +3,12 @@ import re #For remove_attention regular expressions
 from modules import scripts, deepbooru
 from modules.processing import process_images
 import modules.shared as shared
-
+import os # Used for saving previous custom prompt
 
 """
 
 Thanks to Mathias Russ.
-Thanks to RookHyena.
+Thanks to Smirking Kitsune.
 
 """
 
@@ -21,20 +21,41 @@ class Script(scripts.Script):
     def show(self, is_img2img):
         return is_img2img
 
+    def b_clicked(o):
+        return gr.Button.update(interactive=True)
+    
     def ui(self, is_img2img):
-        in_front = gr.Checkbox(label="Prompt in front", value=True)
-        prompt_weight = gr.Slider(
-            0.0, 1.0, value=0.5, step=0.1, label="interrogator weight"
-        )
-        use_weight = gr.Checkbox(label="Use Weighted Prompt", value=True)
-        
+        # Function to load custom filter from file
+        def load_custom_filter(custom_filter):
+            with open("extensions\sd-Img2img-batch-interrogator\custom_filter.txt", "r") as file:
+                custom_filter = file.read()
+                return custom_filter
+
         model_options = ["CLIP", "Deepbooru"]
         model_selection = gr.Dropdown(choices=model_options, label="Select Interrogation Model(s)", multiselect=True, value="Deepbooru")
         
-        with gr.Accordion("Deepbooru tools:"):
+        in_front = gr.Checkbox(label="Prompt in front", value=True)
+        use_weight = gr.Checkbox(label="Use Interrogator Prompt Weight", value=True)
+        prompt_weight = gr.Slider(
+            0.0, 1.0, value=0.5, step=0.1, label="Interrogator Prompt Weight"
+        )
+        
+        with gr.Accordion("Filtering tools:"):
             no_duplicates = gr.Checkbox(label="Filter Duplicate Prompt Content from Interrogation", value=False)
             use_negatives = gr.Checkbox(label="Filter Negative Prompt Content from Interrogation", value=False)
-        return [in_front, prompt_weight, model_selection, use_weight, no_duplicates, use_negatives]
+            use_custom_filter = gr.Checkbox(label="Filter Custom Prompt Content from Interrogation", value=False)
+            custom_filter = gr.Textbox(
+                label="Custom Filter Prompt", 
+                placeholder="Prompt content seperated by commas. Warning ignores attention syntax, parentheses '()' and colon suffix ':XX.XX' are discarded.", 
+                show_copy_button=True
+            )
+            # Button to load custom filter from file
+            load_custom_filter_button = gr.Button(value="Load Last Custom Filter")
+            
+        # Listeners
+        load_custom_filter_button.click(load_custom_filter, inputs=custom_filter, outputs=custom_filter)
+        
+        return [in_front, prompt_weight, model_selection, use_weight, no_duplicates, use_negatives, use_custom_filter, custom_filter]
 
 
     # Required to parse information from a string that is between () or has :##.## suffix
@@ -101,8 +122,13 @@ class Script(scripts.Script):
             interrogator = self.filter_words(interrogator, raw_prompt)
         # Remove negative prompt content from interrogator prompt
         if use_negatives:
-            raw_negative = p.negative_prompt
-            interrogator = self.filter_words(interrogator, raw_negative)
+            interrogator = self.filter_words(interrogator, p.negative_prompt)
+        # Remove custom prompt content from interrogator prompt
+        if use_custom_filter:
+            interrogator = self.filter_words(interrogator, custom_filter)
+            # Save custom filter to text file
+            with open("extensions\sd-Img2img-batch-interrogator\custom_filter.txt", "w") as file:
+                file.write(custom_filter)
 
         if use_weight:
             if p.prompt == "":


### PR DESCRIPTION
Allows users to filter out content from the interrogation without having to put it in the prompt or negative prompt. This also allows users to reuse their custom filters from a previous run, allowing users to keep their filters through different sessions. 

**Custom Prompt Filter is disabled by default, to maintain vanilla workflow**, though I don't think it would do anything even if it was enabled when the custom prompt is empty.

Previous sessions where the custom filtering prompt was used are saved as `custom_filter.txt` to the `extensions\sd-Img2img-batch-interrogator` directory. This file should only be saved if the custom prompt was used. Pressing the button should load the `custom_filter.txt` into the `custom_filter` textbox.
___
There are also some UI cleanup items. Such as moving the model select dropdown to the top of the UI, instead of being at the bottom. Changed "Deepbooru Tools" to "Filtering Tools" since it is being applied to CLIP too. I changed "interrogator weight" to "Interrogator Prompt Weight", and "Use Weighted Prompt" to "Use Interrogator Prompt Weight", to make it clearer to the user what these options do. I also changed my username in the comments.

I had initially attempted to hide the `prompt_weight` slider and the `custom_filter` textbox if the user had unchecked the `use_weight` or `use_custom_filter` checkboxes. Since those interactable components were not in use, users unfamiliar with the code could assume that they are doing something since they are still visible. However, I was unable to get it to work, so most of the cleanup items are remnants of my trying to implement a visibility update function. I determined that the custom filter feature was too fun to sit on, so I just ripped out the broken visibility code for the commit. The `use_custom_filter` checkbox being above the `prompt_weight` slider is one of the most notable remnants of this. 

I will post what the UI function looked like before I removed the broken visibility code below, please note that the code below is currently non-functional, but the code in the commit is functional:
```Python
    def ui(self, is_img2img):
        # Function to load custom filter from file
        def load_custom_filter(custom_filter):
            with open("extensions\sd-Img2img-batch-interrogator\custom_filter.txt", "r") as file:
                custom_filter = file.read()
                return custom_filter
                
        # Function to update visibility of interactable components
        def update_visibility(interactable):
            interactable[0].visibility = interactable[1]
            return interactable[0]

        model_options = ["CLIP", "Deepbooru"]
        model_selection = gr.Dropdown(choices=model_options, label="Select Model(s)", multiselect=True, value="Deepbooru")
                
        in_front = gr.Checkbox(label="Prompt in front", value=True)
        use_weight = gr.Checkbox(label="Use Interrogator Prompt Weight", value=True)
        prompt_weight = gr.Slider(
            0.0, 1.0, value=0.5, step=0.1, label="Interrogator Prompt Weight"
        )
        
        with gr.Accordion("Filter tools:", open=False):
            no_duplicates = gr.Checkbox(label="Filter Duplicate Prompt Content from Interrogation", value=False)
            use_negatives = gr.Checkbox(label="Filter Negative Prompt Content from Interrogation", value=False)
            use_custom_filter = gr.Checkbox(label="Filter Custom Prompt Content from Interrogation", value=False)
            custom_filter = gr.Textbox(
                label="Custom Filter Prompt", 
                placeholder="Prompt content seperated by commas. Warning ignores attention syntax, parentheses '()' and colon suffix ':XX.XX' are discarded.", 
                show_copy_button=True
            )
            # Button to load custom filter from file
            load_custom_filter_button = gr.Button(value="Load Last Custom Filter")
            
        # Listeners
        load_custom_filter_button.click(load_custom_filter, inputs=custom_filter, outputs=custom_filter)
        use_weight.input(update_visibility, input=[prompt_weight, use_weight], output=prompt_weight)
        use_custom_filter.input(update_visibility, input=[custom_filter, use_custom_filter], output=custom_filter)

        return [in_front, prompt_weight, model_selection, use_weight, no_duplicates, use_negatives, use_custom_filter, custom_filter]
```
As far as I can tell the `use_weight` and `use_custom_filter` listeners cause the UI to freeze, preventing the run from getting expected variables. 